### PR TITLE
🔧 chore(docs): fix incorrect directory name in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Alternatively, you can clone the repository and run the following command for lo
 
 ```bash
 $ git clone https://github.com/littleCareless/dish-ai-commit
-$ cd ai-commit
+$ cd dish-ai-commit
 $ npm install
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -384,7 +384,7 @@
 
 ```bash
 $ git clone https://github.com/littleCareless/dish-ai-commit
-$ cd ai-commit
+$ cd dish-ai-commit
 $ npm install
 ```
 


### PR DESCRIPTION
- changed directory name from 'ai-commit' to 'dish-ai-commit' in both English and Chinese README files
- this ensures consistency with the actual repository name